### PR TITLE
Fix typing inconsistencies and add checks for the channel object

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,11 +10,11 @@ REFRESH_TIME = 60 # seconds
 LB_CHANNEL_ID = 913896034579673138
 LB_API_SERVER = "https://openhexagon.fun:8001"
 
-def log(str):
+def log(s : str):
     ms = time.time() - math.floor(time.time())
-    ms = ("%.3f" % ms).lstrip('0')
+    ms_f = ("%.3f" % ms).lstrip('0')
     time_str = time.strftime("%Y-%m-%d %H:%M:%S")
-    print(f"OH-Leaderboard-Bot ({time_str}{ms}): " + str)
+    print(f"OH-Leaderboard-Bot ({time_str}{ms_f}): " + s)
 
 class leaderboard_client(discord.Client):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
I use MyPy to statically type check Python code. I find it incredibly useful to help catch a lot of errors related to typing, which tends to cause a lot of runtime errors. And ideally, I would like if this repository were to use type hinting and annotation, but today is not that day.

This pull request addresses basic inconsistencies that would throw errors on a type checker. This includes not reassigning variables to different types, assuring that the user and channel exist, and asserts that the output channel is a discord.TextChannel (as `CategoryChannel` and `ForumChannel` do not support `fetch_message` or `send`)