### PR TITLE
Make the amount of scores required to emit a top score configurable

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import discord
 from discord.ext import tasks
 
 REFRESH_TIME = 60 # seconds
+SCORES_THRESHOLD = 3
 LB_CHANNEL_ID = 412356109018595329
 LB_API_SERVER = "https://openhexagon.fun:8001"
 
@@ -76,9 +77,9 @@ class leaderboard_client(discord.Client):
                     num_lb_scores = len(lb_scores)
                 except:
                     log(f"WARNING: Could not get leaderboard for {LB_API_SERVER}/get_leaderboard/{pack_ID_str}/{level_ID_str}/{level_options_str}.")
-                    num_lb_scores = 5 # arbitrary number greater than 3
+                    num_lb_scores = SCORES_THRESHOLD + 2
 
-                if num_lb_scores >= 3:
+                if num_lb_scores >= SCORES_THRESHOLD:
                     pack_name = self.pack_lookup[pack_ID]["pack_name"]
                     level_name = self.pack_lookup[pack_ID]["levels"][level_ID][0]
                     num_diffs = self.pack_lookup[pack_ID]["levels"][level_ID][1]


### PR DESCRIPTION
I made this quick PR after hearing concern from some of the competitive players in the Discord server, and that even with our strict settings that the bot can become too spammy.

Someone did mention that this can definitely happen if someone creates a new level or goes into a difficulty that isn't often played. I think it's fair enough that we should also make the threshold for the amount of scores needed before the bot can emit the score configurable as well.

Plus, it's also bad convention to have "magic numbers" that don't have a clear meaning on what they do.