### PR TITLE
Add type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 token.txt
 misc/packs.txt
 misc/level_lookup.py
+typings/discord

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 This is a simple discord bot for periodically posting new scores from the Open Hexagon community leaderboards (not official leaderboards). Written in Python with [discord.py](https://discordpy.readthedocs.io/en/latest/index.html).
 
 ## Quickstart
-1. Install python if it isn't installed already. Navigate your terminal to the source directory.
+1. Install python (preferably 3.13 or newer) if it isn't installed already. Navigate your terminal to the source directory.
 
 2. Install the dependencies, `discord` and `requests`. Using a virtual environment is recommended for distro-agnosticy. 
     - `python -m venv bot-env`
     - `source bot-env/bin/activate`
     - `pip install discord requests`
-
+    - **(Optional, but recommended)** Use a static type checker to avoid annoying typing-related errors when modifying code. You can use [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance), or the FOSS [basedpyright](https://docs.basedpyright.com/latest/) extension.
 3. Create a file called `token.txt`, containing solely the authentification token for your bot, which you can find in the [Discord Developer Portal](https://discord.com/developers/applications).
 
 4. Run the bot with `python main.py`

--- a/main.py
+++ b/main.py
@@ -111,8 +111,8 @@ class leaderboard_client(discord.Client):
                 "last_call_timestamp": 0,
                 "recent_scores": []
             }
-        current_time: float = time.time()
-        time_difference: int = math.ceil(current_time - saved_state["last_call_timestamp"])
+        current_time = time.time()
+        time_difference = math.ceil(current_time - saved_state["last_call_timestamp"])
         saved_state["last_call_timestamp"] = current_time
 
         log(f"Requesting scores from the past {time_difference} seconds.")
@@ -129,15 +129,15 @@ class leaderboard_client(discord.Client):
     async def send_wrs(self, scores_json: list[Score_Dict], saved_state: Task_State):
         channel: TextChannel = self.get_output_channel()
         for score in scores_json:
-            rank: int = score["position"]
+            rank = score["position"]
 
             if rank == 1:
-                pack_ID: str = score["pack"]
-                level_ID: str = score["level"]
+                pack_ID = score["pack"]
+                level_ID = score["level"]
 
-                pack_ID_str: str = urllib.parse.quote(pack_ID)
-                level_ID_str: str = urllib.parse.quote(level_ID)
-                level_options_str: str = urllib.parse.quote(json.dumps(score["level_options"]))
+                pack_ID_str = urllib.parse.quote(pack_ID)
+                level_ID_str = urllib.parse.quote(level_ID)
+                level_options_str = urllib.parse.quote(json.dumps(score["level_options"]))
 
                 try:
                     lb_scores: JSON_Dict = cast(JSON_Dict, requests.get(f"{LB_API_SERVER}/get_leaderboard/{pack_ID_str}/{level_ID_str}/{level_options_str}").json())
@@ -147,8 +147,6 @@ class leaderboard_client(discord.Client):
                     num_lb_scores = SCORES_THRESHOLD # allow score
 
                 if num_lb_scores >= SCORES_THRESHOLD:
-                    pack_name: str
-                    level_name: str
                     try:
                         pack_name = self.pack_lookup[pack_ID]["pack_name"]
                         level_name = self.pack_lookup[pack_ID]["levels"][level_ID][0]
@@ -159,9 +157,9 @@ class leaderboard_client(discord.Client):
                         pack_name = self.pack_lookup[pack_ID]["pack_name"]
                         level_name = self.pack_lookup[pack_ID]["levels"][level_ID][0]
 
-                    num_diffs: int = self.pack_lookup[pack_ID]["levels"][level_ID][1]
-                    mult: str = f"{score['level_options']['difficulty_mult']:.6g}"
-                    diff: str = ""
+                    num_diffs = self.pack_lookup[pack_ID]["levels"][level_ID][1]
+                    mult = f"{score['level_options']['difficulty_mult']:.6g}"
+                    diff = ""
 
                     if num_diffs > 1:
                         diff = f" [x{mult}]"
@@ -171,20 +169,20 @@ class leaderboard_client(discord.Client):
                         self.create_lookup_table()
                         diff = f" [x{mult}]"
 
-                    player: str = score["user_name"]
+                    player = score["user_name"]
                     run_length: float = round(score["value"], 3)
 
                     if pack_name[0] == "#":
                         pack_name = "\\" + pack_name
 
-                    score_text: str = f"**{pack_name} - {level_name}{diff}** <:hexagon:1388672832094867486> **{player}** achieved **#{rank}** with a score of **{run_length}**"
+                    score_text = f"**{pack_name} - {level_name}{diff}** <:hexagon:1388672832094867486> **{player}** achieved **#{rank}** with a score of **{run_length}**"
 
                     # remove old messages from the edit queue
                     for last_score in saved_state["recent_scores"]:
                         if score["timestamp"] - last_score["timestamp"] > EDIT_TIME:
                             saved_state["recent_scores"].remove(last_score)
 
-                    edited: bool = False
+                    edited = False
                     msg: Message | None = None
                     # check if score could be edited into a previous message 
                     for last_score in saved_state["recent_scores"]:
@@ -236,8 +234,8 @@ class leaderboard_client(discord.Client):
                     queue.pop(0)
                     return
             # check if video exists
-            replay_hash: str = score["replay_hash"]
-            video_link: str = f"{LB_API_SERVER}/get_video/{replay_hash}"
+            replay_hash = score["replay_hash"]
+            video_link = f"{LB_API_SERVER}/get_video/{replay_hash}"
             try:
                 response_headers = requests.get(video_link, headers={"Range": "bytes=0-0"}).headers
             except Exception as e:
@@ -247,7 +245,7 @@ class leaderboard_client(discord.Client):
                 # exists now, edit message to include link
                 assert isinstance(score["message_id"], int), "Can't attach video to a score with no assigned Discord message"
                 message = await channel.fetch_message(score["message_id"])
-                run_length: float = round(score["value"], 3)
+                run_length = round(score["value"], 3)
 
                 # remove previous links
                 new_content = re.sub("\\[(.+)\\]\\(.+\\)", "\\1", message.content)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,18 @@
+{
+  "include": [
+    "main.py"
+  ],
+
+  "exclude": [
+    "**/node_modules",
+    "**/__pycache__",
+    "typings"
+  ],
+
+  "stubPath": "typings",
+
+  "pythonVersion": "3.13",
+
+  // Exempt these rules. They're too pedantic and hurts legibility
+  "reportUnusedCallResult": false,
+}


### PR DESCRIPTION
This is kind of a part 1 of refactoring the script to make it a ton more maintainable. This merge request refactors the script to use type hints, an optional albeit incredibly useful feature of Python. By adding type hinting into the script and development workflow, we can eliminate a whole class of errors. 

Since discord.py doesn't come with its own type stubs by default, I autogenerated them using my type checker so hopefully all typing logic related to discord.py should be handled. Any remaining errors that I found from my type checker have been explicitly ignored, as we don't want to change discord.py logic.

In addition, I also created a config file specifically to the project so that we can not only configure where type checkers should be looking, but also make it so that we can globally ignore certain issues that can be raised by the pyright type checker. For example, I chose to ignore the `reportUnusedCallResult` rule because I find this rule to be incredibly pedantic (even for typed languages) and will just hurt legibility more than it offers a benefit. 

I am open to blacklisting more rules if you do find them to be too pedantic (i.e. should we allow implicit Any if we want to avoid the usage of `cast`?). I want the code base to still be workable for everyone, but at the same time we should make sure that we can catch and eliminate any typing errors that can pop up when modifying the code.

And if you haven't already, you should consider using a static type checker for Python code. I modified the README to include two type checkers that can be used: the popular [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance), but also the FOSS [basedpyright](https://docs.basedpyright.com/latest/) which is what I'm using, as regular pyright has fallen behind quite a bit in features.