### PR TITLE
Fix ambiguity in regex rule where it matches starting brace of difficulty string

### DIFF
--- a/main.py
+++ b/main.py
@@ -183,7 +183,7 @@ class leaderboard_client(discord.Client):
                 run_length = round(score["value"], 3)
 
                 # remove previous links
-                new_content = re.sub("\\[(.+)\\]\\(.+\\)", "\\1", message.content)
+                new_content = re.sub(r"\[(\d+(\.\d*)?)\]\(.+\)", r"\1", message.content)
                 # add newest link
                 new_content = rreplace(new_content, f"**{run_length}**", f"**[{run_length}]({video_link}) **")
 


### PR DESCRIPTION
The regex pattern that is being used has an issue where, because of the fact that square braces [] are also used to display the difficulty of a level, it will match with the starting brace of the difficulty string instead of the brace that's the beginning of the hyperlinked text. That's because this regex rule doesn't care what or how many characters are between the starting and closing brace; as long as there's a closing brace, it's a match.

<img width="3007" height="888" alt="image" src="https://github.com/user-attachments/assets/37b44938-d7fc-4e91-a7fa-35f90ef0541f" />

This regex rule makes things less ambiguous, as there must be a strictly numeric value between the braces for it to match. I didn't know how the bot formats strings that are whole integers, so I made it so that the decimal point is optional.

Also, when defining a regex string, use raw strings (R strings). That way you don't have to deal with the hell of constantly escaping backslashes. 